### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/167/921/421167921.geojson
+++ b/data/421/167/921/421167921.geojson
@@ -564,6 +564,9 @@
     },
     "wof:country":"GM",
     "wof:created":1459008747,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d8979350cd82ce250775a40fd61cbfb",
     "wof:hierarchy":[
         {
@@ -572,7 +575,7 @@
         }
     ],
     "wof:id":421167921,
-    "wof:lastmodified":1566639000,
+    "wof:lastmodified":1582358171,
     "wof:name":"Banjul",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/177/715/421177715.geojson
+++ b/data/421/177/715/421177715.geojson
@@ -202,6 +202,9 @@
     },
     "wof:country":"GM",
     "wof:created":1459009158,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"adb5f7fd36aec4ccfcbc70fd6d9682c8",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421177715,
-    "wof:lastmodified":1566639003,
+    "wof:lastmodified":1582358171,
     "wof:name":"Kerewan",
     "wof:parent_id":890422473,
     "wof:placetype":"locality",

--- a/data/856/326/03/85632603.geojson
+++ b/data/856/326/03/85632603.geojson
@@ -929,6 +929,11 @@
     },
     "wof:country":"GM",
     "wof:country_alpha3":"GMB",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"43ce0f638e112b0d0860d6989c190a6c",
     "wof:hierarchy":[
         {
@@ -943,7 +948,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638891,
+    "wof:lastmodified":1582358170,
     "wof:name":"Gambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/07/85671507.geojson
+++ b/data/856/715/07/85671507.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Central River Division"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f6dc6484b2fdf4890526b042b2fff37",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638891,
+    "wof:lastmodified":1582358169,
     "wof:name":"Central River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/11/85671511.geojson
+++ b/data/856/715/11/85671511.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Upper River Division"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec0c86b9529bec80acdccb1c04d1db99",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638890,
+    "wof:lastmodified":1582358169,
     "wof:name":"Upper River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/17/85671517.geojson
+++ b/data/856/715/17/85671517.geojson
@@ -531,6 +531,9 @@
         "wd:id":"Q3726"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"531bac4606c9679f6bbb2a50caab610d",
     "wof:hierarchy":[
         {
@@ -546,7 +549,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638890,
+    "wof:lastmodified":1582358169,
     "wof:name":"Banjul",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/21/85671521.geojson
+++ b/data/856/715/21/85671521.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Lower River Division"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"146b51eea2294f36a31c70df246b280b",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638890,
+    "wof:lastmodified":1582358169,
     "wof:name":"Lower River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/25/85671525.geojson
+++ b/data/856/715/25/85671525.geojson
@@ -279,6 +279,9 @@
         "wk:page":"West Coast Division (Gambia)"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f270fe33f08131140ea276247c54d354",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638891,
+    "wof:lastmodified":1582358170,
     "wof:name":"West Coast",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/29/85671529.geojson
+++ b/data/856/715/29/85671529.geojson
@@ -280,6 +280,9 @@
         "wk:page":"North Bank Division"
     },
     "wof:country":"GM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b286427b091209cd6fd429d82809ff45",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566638890,
+    "wof:lastmodified":1582358169,
     "wof:name":"North Bank",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/890/413/179/890413179.geojson
+++ b/data/890/413/179/890413179.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7200273df80062f05b7eaa950e1b100f",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890413179,
-    "wof:lastmodified":1566639031,
+    "wof:lastmodified":1582358173,
     "wof:name":"Wuli",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/413/197/890413197.geojson
+++ b/data/890/413/197/890413197.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050991,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47fe8a4694ed41bd483a83b4324e1c3d",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890413197,
-    "wof:lastmodified":1566639025,
+    "wof:lastmodified":1582358173,
     "wof:name":"Upper Saloum",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/413/199/890413199.geojson
+++ b/data/890/413/199/890413199.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050991,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5aee57576b3a506251465a046e83953b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890413199,
-    "wof:lastmodified":1566639026,
+    "wof:lastmodified":1582358173,
     "wof:name":"Upper Niumi",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/413/201/890413201.geojson
+++ b/data/890/413/201/890413201.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050991,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db71a32e189391de2329b16aaf5f4100",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890413201,
-    "wof:lastmodified":1566639029,
+    "wof:lastmodified":1582358173,
     "wof:name":"Upper Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/413/347/890413347.geojson
+++ b/data/890/413/347/890413347.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91fa78232a9a38df56cc1e076ed31e8f",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890413347,
-    "wof:lastmodified":1566639024,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kombo South",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/349/890413349.geojson
+++ b/data/890/413/349/890413349.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46dfe4873aee634ca467b43d9d082050",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890413349,
-    "wof:lastmodified":1566639023,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kombo North",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/351/890413351.geojson
+++ b/data/890/413/351/890413351.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"465b0e062f2884aa7876e185cc28d2ce",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890413351,
-    "wof:lastmodified":1566639025,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kombo East",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/355/890413355.geojson
+++ b/data/890/413/355/890413355.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b39ade178d034290a024d646968804e0",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890413355,
-    "wof:lastmodified":1566639018,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kombo Central",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/365/890413365.geojson
+++ b/data/890/413/365/890413365.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a1db1518e40efda1d5d12e9f427c038",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890413365,
-    "wof:lastmodified":1566639017,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kiang West",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/413/367/890413367.geojson
+++ b/data/890/413/367/890413367.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51a6ad473815275a595170dc2ce89158",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890413367,
-    "wof:lastmodified":1566639025,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kiang East",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/413/369/890413369.geojson
+++ b/data/890/413/369/890413369.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469050998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"931840fac9b53b4c12479afb8ee6700f",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890413369,
-    "wof:lastmodified":1566639025,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kiang Central",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/469/890422469.geojson
+++ b/data/890/422/469/890422469.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051447,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65b9f1d48854bfe70288cd9e144f3151",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890422469,
-    "wof:lastmodified":1566639014,
+    "wof:lastmodified":1582358172,
     "wof:name":"Lower Saloum",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/471/890422471.geojson
+++ b/data/890/422/471/890422471.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051447,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebd5c620e4ab9d5319647ae41edbd982",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890422471,
-    "wof:lastmodified":1566639007,
+    "wof:lastmodified":1582358172,
     "wof:name":"Lower Niumi",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/473/890422473.geojson
+++ b/data/890/422/473/890422473.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051448,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85266a9d401dac6f1b4b3ea457a4df07",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890422473,
-    "wof:lastmodified":1566639012,
+    "wof:lastmodified":1582358172,
     "wof:name":"Lower Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/613/890422613.geojson
+++ b/data/890/422/613/890422613.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051455,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1e04812c4a7a42486ab5de2b05aba4e",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890422613,
-    "wof:lastmodified":1566639011,
+    "wof:lastmodified":1582358172,
     "wof:name":"Sami",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/629/890422629.geojson
+++ b/data/890/422/629/890422629.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051456,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57da74456b44eda10466ad83d333ea22",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422629,
-    "wof:lastmodified":1566639009,
+    "wof:lastmodified":1582358172,
     "wof:name":"Niamina West",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/631/890422631.geojson
+++ b/data/890/422/631/890422631.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051456,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a62b37a4bedcbc0c38bf9320d9a5dd12",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422631,
-    "wof:lastmodified":1566639015,
+    "wof:lastmodified":1582358172,
     "wof:name":"Niamina East",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/649/890422649.geojson
+++ b/data/890/422/649/890422649.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051457,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3048b3d5cc76f2bf2c23e95943aceb6f",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890422649,
-    "wof:lastmodified":1566639011,
+    "wof:lastmodified":1582358172,
     "wof:name":"Jokadu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/673/890422673.geojson
+++ b/data/890/422/673/890422673.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051459,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5d01a8ce1a982e2fef4fde33afba2f7",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890422673,
-    "wof:lastmodified":1566639009,
+    "wof:lastmodified":1582358172,
     "wof:name":"Jarra West",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/675/890422675.geojson
+++ b/data/890/422/675/890422675.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051459,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"87da3e798e6dc13f5fd7578f332c355b",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422675,
-    "wof:lastmodified":1566639006,
+    "wof:lastmodified":1582358172,
     "wof:name":"Jarra East",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/679/890422679.geojson
+++ b/data/890/422/679/890422679.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051459,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"094102fe9ad98d85183107be2a80ad93",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422679,
-    "wof:lastmodified":1566639013,
+    "wof:lastmodified":1582358172,
     "wof:name":"Jarra Central",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/703/890422703.geojson
+++ b/data/890/422/703/890422703.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051460,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dade35b229b56bcbd315ab194cab81a8",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422703,
-    "wof:lastmodified":1566639011,
+    "wof:lastmodified":1582358172,
     "wof:name":"Foni Kansala",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/705/890422705.geojson
+++ b/data/890/422/705/890422705.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051460,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58642c04fd1adfdc7b62122c3dbed1bf",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422705,
-    "wof:lastmodified":1566639011,
+    "wof:lastmodified":1582358172,
     "wof:name":"Foni Jarrol",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/707/890422707.geojson
+++ b/data/890/422/707/890422707.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051460,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b229e0fdf0ca3eaa9d8fcb8570306a3d",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422707,
-    "wof:lastmodified":1566639006,
+    "wof:lastmodified":1582358172,
     "wof:name":"Foni Brefet",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/709/890422709.geojson
+++ b/data/890/422/709/890422709.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051460,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89fd13568d3fe55bcbc97df1d7e46465",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890422709,
-    "wof:lastmodified":1566639006,
+    "wof:lastmodified":1582358172,
     "wof:name":"Foni Bondali",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/845/890422845.geojson
+++ b/data/890/422/845/890422845.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051468,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"106d418dd99bcde69c759cc5db8411ef",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":890422845,
-    "wof:lastmodified":1566639007,
+    "wof:lastmodified":1582358172,
     "wof:name":"Nianija",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/847/890422847.geojson
+++ b/data/890/422/847/890422847.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051468,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81da20515e7bd3a9bbf86c7a05c2270d",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890422847,
-    "wof:lastmodified":1566639012,
+    "wof:lastmodified":1582358172,
     "wof:name":"Niani",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/429/021/890429021.geojson
+++ b/data/890/429/021/890429021.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051788,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62a400c339a5b1c088b6bef7d684d97c",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890429021,
-    "wof:lastmodified":1566639045,
+    "wof:lastmodified":1582358173,
     "wof:name":"Sandu",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/041/890429041.geojson
+++ b/data/890/429/041/890429041.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051789,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d01ef12e5922cf72f1e7c77a40b52210",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890429041,
-    "wof:lastmodified":1566639042,
+    "wof:lastmodified":1582358173,
     "wof:name":"Kantora",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/055/890429055.geojson
+++ b/data/890/429/055/890429055.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051790,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0f15ea72488fc690af361054a4f2279",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890429055,
-    "wof:lastmodified":1566639043,
+    "wof:lastmodified":1582358173,
     "wof:name":"Fulladu West",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/429/057/890429057.geojson
+++ b/data/890/429/057/890429057.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051790,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b349c5c81cb926c7ab6a3e97257dd6c1",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890429057,
-    "wof:lastmodified":1566639045,
+    "wof:lastmodified":1582358173,
     "wof:name":"Fulladu East",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/071/890429071.geojson
+++ b/data/890/429/071/890429071.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469051791,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df2d898b87fb0d74ef7d54894cd71450",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":890429071,
-    "wof:lastmodified":1566639042,
+    "wof:lastmodified":1582358173,
     "wof:name":"Central Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/453/459/890453459.geojson
+++ b/data/890/453/459/890453459.geojson
@@ -44,6 +44,9 @@
     },
     "wof:country":"GM",
     "wof:created":1469052855,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abe1b2cebd0ad1861389c89d2a46a940",
     "wof:hierarchy":[
         {
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":890453459,
-    "wof:lastmodified":1566639038,
+    "wof:lastmodified":1582358173,
     "wof:name":"Panchang Madi Fana",
     "wof:parent_id":890413197,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.