### PR TITLE
gm placetype local and more

### DIFF
--- a/data/856/326/03/85632603.geojson
+++ b/data/856/326/03/85632603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.891857,
-    "geom:area_square_m":10725356581.011753,
+    "geom:area_square_m":10725356054.142286,
     "geom:bbox":"-16.817083,13.065308,-13.798611,13.826389",
     "geom:latitude":13.4531,
     "geom:longitude":-15.387105,
@@ -14,6 +14,9 @@
     "iso:country":"GM",
     "itu:country_code":[
         "220"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "GM"
@@ -1043,7 +1046,8 @@
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"geonames",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"220",
     "statoids:ds":"WAG",
     "statoids:fifa":"GAM",
@@ -1097,7 +1101,7 @@
         "naturalearth",
         "naturalearth-display-terrestrial-zoom6"
     ],
-    "wof:geomhash":"f9a35f038ee1a54657986df46ba60043",
+    "wof:geomhash":"7d21a14314615e61682fce309322abf4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -1111,12 +1115,12 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921821,
+    "wof:lastmodified":1694492102,
     "wof:name":"Gambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",
-    "wof:population":1593256,
-    "wof:population_rank":12,
+    "wof:population":2347706,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-gm",
     "wof:shortcode":"GM",
     "wof:superseded_by":[],

--- a/data/856/326/03/85632603.geojson
+++ b/data/856/326/03/85632603.geojson
@@ -1047,7 +1047,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"220",
     "statoids:ds":"WAG",
     "statoids:fifa":"GAM",
@@ -1115,7 +1115,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694492102,
+    "wof:lastmodified":1694639555,
     "wof:name":"Gambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2154. Sets placetype local, names, populations, and statoids properties for CARTO