### PR TITLE
gm concordances, placetype local, and more

### DIFF
--- a/data/110/856/261/9/1108562619.geojson
+++ b/data/110/856/261/9/1108562619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024308,
-    "geom:area_square_m":292593424.081492,
+    "geom:area_square_m":292592896.527433,
     "geom:bbox":"-16.368534,13.16443,-16.112434,13.322971",
     "geom:latitude":13.235747,
     "geom:longitude":-16.224069,
@@ -94,9 +94,10 @@
         "hasc:id":"GM.WE.FO",
         "wd:id":"Q1421161"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1474051424,
-    "wof:geomhash":"13da1497bcaf06ad7aa18f92de9a916b",
+    "wof:geomhash":"80c02c561bf8a853b1bce74c7581f1c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108562619,
-    "wof:lastmodified":1690921821,
+    "wof:lastmodified":1695886315,
     "wof:name":"Foni Bintang-Karenai",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/110/856/262/1/1108562621.geojson
+++ b/data/110/856/262/1/1108562621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000895,
-    "geom:area_square_m":10766267.59673,
+    "geom:area_square_m":10766267.596728,
     "geom:bbox":"-16.6282336603,13.4335713683,-16.5746336603,13.4719713683",
     "geom:latitude":13.45072,
     "geom:longitude":-16.596561,
@@ -413,9 +413,10 @@
     "wof:concordances":{
         "hasc:id":"GM.BJ.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1474051428,
-    "wof:geomhash":"31853e30c22f963385d1779aac25743d",
+    "wof:geomhash":"74d331f1044929ec8fae00a95dd17aa9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -425,7 +426,7 @@
         }
     ],
     "wof:id":1108562621,
-    "wof:lastmodified":1566638966,
+    "wof:lastmodified":1695886315,
     "wof:name":"Banjul",
     "wof:parent_id":85671517,
     "wof:placetype":"county",

--- a/data/110/856/262/3/1108562623.geojson
+++ b/data/110/856/262/3/1108562623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006677,
-    "geom:area_square_m":80301242.281789,
+    "geom:area_square_m":80300704.597921,
     "geom:bbox":"-16.725962,13.39209,-16.606334,13.488671",
     "geom:latitude":13.441602,
     "geom:longitude":-16.661014,
@@ -112,9 +112,10 @@
         "hasc:id":"GM.BJ.KF",
         "wd:id":"Q1762211"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1474051429,
-    "wof:geomhash":"b0983eaa17e346a1356da904eaf8bf6b",
+    "wof:geomhash":"ba9928573a2e07bdead34b8566e4089d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108562623,
-    "wof:lastmodified":1690921822,
+    "wof:lastmodified":1695886315,
     "wof:name":"Kanifing",
     "wof:parent_id":85671517,
     "wof:placetype":"county",

--- a/data/110/856/262/7/1108562627.geojson
+++ b/data/110/856/262/7/1108562627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010344,
-    "geom:area_square_m":124308829.008942,
+    "geom:area_square_m":124308829.202491,
     "geom:bbox":"-15.366634,13.515271,-15.264334,13.690171",
     "geom:latitude":13.614835,
     "geom:longitude":-15.325616,
@@ -87,9 +87,10 @@
         "hasc:id":"GM.MC.ND",
         "wd:id":"Q1572217"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1474051436,
-    "wof:geomhash":"b20bfb67597753d71c61acbf2f6793c2",
+    "wof:geomhash":"ab0791d83456cce3b21459c1be2ca6ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108562627,
-    "wof:lastmodified":1690921822,
+    "wof:lastmodified":1695886315,
     "wof:name":"Niamina Dankunku",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/856/326/03/85632603.geojson
+++ b/data/856/326/03/85632603.geojson
@@ -1081,6 +1081,7 @@
         "hasc:id":"GM",
         "icao:code":"C5",
         "ioc:id":"GAM",
+        "iso:code":"GM",
         "itu:id":"GMB",
         "m49:code":"270",
         "marc:id":"gm",
@@ -1094,6 +1095,7 @@
         "wk:page":"The Gambia",
         "wmo:id":"GB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:country_alpha3":"GMB",
     "wof:geom_alt":[
@@ -1115,7 +1117,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639555,
+    "wof:lastmodified":1695881213,
     "wof:name":"Gambia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/715/07/85671507.geojson
+++ b/data/856/715/07/85671507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252251,
-    "geom:area_square_m":3031684145.904158,
+    "geom:area_square_m":3031685787.202534,
     "geom:bbox":"-15.466104,13.324065,-14.449391,13.82829",
     "geom:latitude":13.598941,
     "geom:longitude":-14.924507,
@@ -295,17 +295,19 @@
         "gn:id":2412707,
         "gp:id":2345445,
         "hasc:id":"GM.MC",
+        "iso:code":"GM-M",
         "iso:id":"GM-M",
         "qs_pg:id":423767,
         "unlc:id":"GM-M",
         "wd:id":"Q824431",
         "wk:page":"Central River Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"762d048bcbe45f2e5c524bc4d5db05f3",
+    "wof:geomhash":"5005c46fd7ce5735ff4e68fba21b2ea7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921819,
+    "wof:lastmodified":1695885131,
     "wof:name":"Central River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/11/85671511.geojson
+++ b/data/856/715/11/85671511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174218,
-    "geom:area_square_m":2095633692.656204,
+    "geom:area_square_m":2095634387.831039,
     "geom:bbox":"-14.548745,13.217627,-13.792053,13.58094",
     "geom:latitude":13.394681,
     "geom:longitude":-14.161808,
@@ -297,17 +297,19 @@
         "gn:id":2411711,
         "gp:id":2345446,
         "hasc:id":"GM.UR",
+        "iso:code":"GM-U",
         "iso:id":"GM-U",
         "qs_pg:id":496856,
         "unlc:id":"GM-U",
         "wd:id":"Q824373",
         "wk:page":"Upper River Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff615886b77178603044af5a07172fc2",
+    "wof:geomhash":"5b5382ff7f09e016f9737904b454c375",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921817,
+    "wof:lastmodified":1695884939,
     "wof:name":"Upper River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/17/85671517.geojson
+++ b/data/856/715/17/85671517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007572,
-    "geom:area_square_m":91067509.87852,
+    "geom:area_square_m":91066972.211195,
     "geom:bbox":"-16.725962,13.39209,-16.574634,13.488671",
     "geom:latitude":13.44268,
     "geom:longitude":-16.653394,
@@ -591,16 +591,18 @@
         "gn:id":2413875,
         "gp:id":2345443,
         "hasc:id":"GM.BJ",
+        "iso:code":"GM-B",
         "iso:id":"GM-B",
         "qs_pg:id":901869,
         "unlc:id":"GM-B",
         "wd:id":"Q3726"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0480484b3e1f12dd084e314c7cb6ed51",
+    "wof:geomhash":"660faf2a1d54e1155e6cb39c6a4e54e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -615,7 +617,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921818,
+    "wof:lastmodified":1695884366,
     "wof:name":"Banjul",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/21/85671521.geojson
+++ b/data/856/715/21/85671521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123076,
-    "geom:area_square_m":1480515244.438986,
+    "geom:area_square_m":1480513222.337109,
     "geom:bbox":"-16.230134,13.247371,-15.166485,13.556885",
     "geom:latitude":13.386718,
     "geom:longitude":-15.740805,
@@ -294,17 +294,19 @@
         "gn:id":2412716,
         "gp:id":2345444,
         "hasc:id":"GM.LR",
+        "iso:code":"GM-L",
         "iso:id":"GM-L",
         "qs_pg:id":423766,
         "unlc:id":"GM-L",
         "wd:id":"Q824421",
         "wk:page":"Lower River Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95104889bbe49d18db0229c8634fa84e",
+    "wof:geomhash":"75310fef73ca74cee51115279f097746",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921819,
+    "wof:lastmodified":1695885133,
     "wof:name":"Lower River",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/25/85671525.geojson
+++ b/data/856/715/25/85671525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.148344,
-    "geom:area_square_m":1785511883.104515,
+    "geom:area_square_m":1785508088.021783,
     "geom:bbox":"-16.825034,13.064271,-15.803606,13.458416",
     "geom:latitude":13.244429,
     "geom:longitude":-16.408755,
@@ -293,17 +293,19 @@
         "gn:id":2411683,
         "gp:id":2345447,
         "hasc:id":"GM.WE",
+        "iso:code":"GM-W",
         "iso:id":"GM-W",
         "qs_pg:id":219555,
         "unlc:id":"GM-W",
         "wd:id":"Q846158",
         "wk:page":"West Coast Division (Gambia)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30d772fc9a4d11bd7360be0df4a576ac",
+    "wof:geomhash":"64c7ce2b4308c8cba918fa97deb58f2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921820,
+    "wof:lastmodified":1695884939,
     "wof:name":"West Coast",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/856/715/29/85671529.geojson
+++ b/data/856/715/29/85671529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187887,
-    "geom:area_square_m":2259004181.889655,
+    "geom:area_square_m":2259007367.428725,
     "geom:bbox":"-16.560034,13.326371,-15.302034,13.643671",
     "geom:latitude":13.506483,
     "geom:longitude":-16.024108,
@@ -288,17 +288,19 @@
         "gn:id":2412353,
         "gp:id":2345448,
         "hasc:id":"GM.NB",
+        "iso:code":"GM-N",
         "iso:id":"GM-N",
         "qs_pg:id":894884,
         "unlc:id":"GM-N",
         "wd:id":"Q846161",
         "wk:page":"North Bank Division"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f5bf749eda937907511820dd38463a4",
+    "wof:geomhash":"3fa2488d8c0f467f98e51c1d8abad8a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690921818,
+    "wof:lastmodified":1695885134,
     "wof:name":"North Bank",
     "wof:parent_id":85632603,
     "wof:placetype":"region",

--- a/data/890/413/179/890413179.geojson
+++ b/data/890/413/179/890413179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051825,
-    "geom:area_square_m":623194959.767353,
+    "geom:area_square_m":623196481.421504,
     "geom:bbox":"-14.282434,13.314771,-13.860481,13.58094",
     "geom:latitude":13.471953,
     "geom:longitude":-14.072469,
@@ -110,12 +110,13 @@
         "wd:id":"Q600022",
         "wk:page":"Wuli"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b74b070afb7a1d9e9a4e908bc6c24d61",
+    "wof:geomhash":"a912489d0f343c9911d70ca86833539f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":890413179,
-    "wof:lastmodified":1690921849,
+    "wof:lastmodified":1695885992,
     "wof:name":"Wuli",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/413/197/890413197.geojson
+++ b/data/890/413/197/890413197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02378,
-    "geom:area_square_m":285628610.286344,
+    "geom:area_square_m":285629804.431783,
     "geom:bbox":"-15.382899,13.643371,-14.991621,13.82829",
     "geom:latitude":13.744858,
     "geom:longitude":-15.198642,
@@ -101,12 +101,13 @@
         "wd:id":"Q1554897",
         "wk:page":"Upper Saloum"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050991,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9273ad12b1235f9b33e1b249b8c04793",
+    "wof:geomhash":"bad41bcc5b188e7f3d4bbb3841702386",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890413197,
-    "wof:lastmodified":1690921847,
+    "wof:lastmodified":1695885992,
     "wof:name":"Upper Saloum",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/413/199/890413199.geojson
+++ b/data/890/413/199/890413199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032698,
-    "geom:area_square_m":393287622.330841,
+    "geom:area_square_m":393287622.933735,
     "geom:bbox":"-16.516734,13.326371,-16.217834,13.530271",
     "geom:latitude":13.41307,
     "geom:longitude":-16.349424,
@@ -104,12 +104,13 @@
         "wd:id":"Q1572223",
         "wk:page":"Aljamdu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050991,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d3287dbeb11cf913d8c9a248ebe38f9",
+    "wof:geomhash":"44633c7dae4c601623aaf20dcb4fee90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890413199,
-    "wof:lastmodified":1690921848,
+    "wof:lastmodified":1695885992,
     "wof:name":"Upper Niumi",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/413/201/890413201.geojson
+++ b/data/890/413/201/890413201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05981,
-    "geom:area_square_m":719012842.891054,
+    "geom:area_square_m":719014887.763817,
     "geom:bbox":"-15.861034,13.437771,-15.302034,13.643671",
     "geom:latitude":13.538397,
     "geom:longitude":-15.581075,
@@ -101,12 +101,13 @@
         "wd:id":"Q657796",
         "wk:page":"Upper Baddibu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050991,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"582f79eaa6462f46d425e9a6c1f267bb",
+    "wof:geomhash":"4879df49cc02d93afe2aad6eb675b1a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890413201,
-    "wof:lastmodified":1690921848,
+    "wof:lastmodified":1695885992,
     "wof:name":"Upper Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/413/347/890413347.geojson
+++ b/data/890/413/347/890413347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027678,
-    "geom:area_square_m":333154089.234511,
+    "geom:area_square_m":333154089.234484,
     "geom:bbox":"-16.8250336603,13.0642713683,-16.6186336603,13.3641713683",
     "geom:latitude":13.235533,
     "geom:longitude":-16.747323,
@@ -110,12 +110,13 @@
         "wd:id":"Q1572017",
         "wk:page":"Gunjur"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"91fa78232a9a38df56cc1e076ed31e8f",
+    "wof:geomhash":"bafb9a8b0cd536d0d447eb045589286e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":890413347,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kombo South",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/349/890413349.geojson
+++ b/data/890/413/349/890413349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014997,
-    "geom:area_square_m":180403881.532211,
+    "geom:area_square_m":180403881.532222,
     "geom:bbox":"-16.8126336603,13.3299713683,-16.5818336603,13.4584159989",
     "geom:latitude":13.37683,
     "geom:longitude":-16.687469,
@@ -117,12 +117,13 @@
         "wd:id":"Q1572418",
         "wk:page":"Kombo South"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46dfe4873aee634ca467b43d9d082050",
+    "wof:geomhash":"1cf7696e0c7bbe3e93e652edcda56430",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":890413349,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kombo North",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/351/890413351.geojson
+++ b/data/890/413/351/890413351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020484,
-    "geom:area_square_m":246569108.428012,
+    "geom:area_square_m":246568267.424383,
     "geom:bbox":"-16.588334,13.166163,-16.404934,13.330371",
     "geom:latitude":13.228134,
     "geom:longitude":-16.507761,
@@ -107,12 +107,13 @@
         "wd:id":"Q1548433",
         "wk:page":"Faraba Banta"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd895d29cd078a3cb6580065711d4ece",
+    "wof:geomhash":"84ef69f80a0891a16ad1b6cad7500138",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":890413351,
-    "wof:lastmodified":1690921847,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kombo East",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/355/890413355.geojson
+++ b/data/890/413/355/890413355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016689,
-    "geom:area_square_m":200869781.520869,
+    "geom:area_square_m":200869781.52086,
     "geom:bbox":"-16.7439336603,13.1664205868,-16.5785336603,13.3337713683",
     "geom:latitude":13.24435,
     "geom:longitude":-16.643127,
@@ -113,12 +113,13 @@
         "wd:id":"Q1572741",
         "wk:page":"Kombo (disambiguation)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b39ade178d034290a024d646968804e0",
+    "wof:geomhash":"2ad2148aac254270b608a77bd1994eb7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":890413355,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kombo Central",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/413/365/890413365.geojson
+++ b/data/890/413/365/890413365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057884,
-    "geom:area_square_m":696422659.4541,
+    "geom:area_square_m":696422659.454122,
     "geom:bbox":"-16.2301336603,13.2473713683,-15.8048064183,13.4432713683",
     "geom:latitude":13.343027,
     "geom:longitude":-16.004993,
@@ -101,12 +101,13 @@
         "wd:id":"Q1572726",
         "wk:page":"Kiang West National Park"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a1db1518e40efda1d5d12e9f427c038",
+    "wof:geomhash":"f5119738e4d124708aca718bb8cd4afd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890413365,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kiang West",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/413/367/890413367.geojson
+++ b/data/890/413/367/890413367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008438,
-    "geom:area_square_m":101493076.008646,
+    "geom:area_square_m":101491906.4811,
     "geom:bbox":"-15.690308,13.350879,-15.598834,13.478871",
     "geom:latitude":13.409808,
     "geom:longitude":-15.647985,
@@ -107,12 +107,13 @@
         "wd:id":"Q1572748",
         "wk:page":"Kiang East"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59433edf7694dbb9c68378e4e42b9d15",
+    "wof:geomhash":"fbb3699c8286dd15d35f3dc750f94571",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":890413367,
-    "wof:lastmodified":1690921847,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kiang East",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/413/369/890413369.geojson
+++ b/data/890/413/369/890413369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012706,
-    "geom:area_square_m":152833754.004534,
+    "geom:area_square_m":152833754.004537,
     "geom:bbox":"-15.826171875,13.3411938979,-15.6892097744,13.4759934453",
     "geom:latitude":13.398256,
     "geom:longitude":-15.755149,
@@ -104,12 +104,13 @@
         "wd:id":"Q1572242",
         "wk:page":"Kiang Central"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469050998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"931840fac9b53b4c12479afb8ee6700f",
+    "wof:geomhash":"f5671484311e55e1df4612183f5b651c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890413369,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kiang Central",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/469/890422469.geojson
+++ b/data/890/422/469/890422469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01348,
-    "geom:area_square_m":161938318.713421,
+    "geom:area_square_m":161938761.531013,
     "geom:bbox":"-15.466104,13.628471,-15.288696,13.767036",
     "geom:latitude":13.696064,
     "geom:longitude":-15.384934,
@@ -101,12 +101,13 @@
         "wd:id":"Q1572755",
         "wk:page":"Lower Saloum"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051447,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0f7ca11c46e13838f9ed4faaa24b5664",
+    "wof:geomhash":"f380eda206bcb4d8534c7c55d58cffad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890422469,
-    "wof:lastmodified":1690921842,
+    "wof:lastmodified":1695885991,
     "wof:name":"Lower Saloum",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/471/890422471.geojson
+++ b/data/890/422/471/890422471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033959,
-    "geom:area_square_m":408272459.164205,
+    "geom:area_square_m":408272459.79527,
     "geom:bbox":"-16.560034,13.413771,-16.289534,13.589971",
     "geom:latitude":13.519294,
     "geom:longitude":-16.428959,
@@ -104,12 +104,13 @@
         "wd:id":"Q915733",
         "wk:page":"Essau"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051447,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"806b7b56bb4811d53bb8e6a53aab4076",
+    "wof:geomhash":"f7eb1354ff394cf02fa203d8afa4a63a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422471,
-    "wof:lastmodified":1690921836,
+    "wof:lastmodified":1695885991,
     "wof:name":"Lower Niumi",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/473/890422473.geojson
+++ b/data/890/422/473/890422473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016395,
-    "geom:area_square_m":197112804.774755,
+    "geom:area_square_m":197112804.774752,
     "geom:bbox":"-16.1369336603,13.4363713683,-15.9982336603,13.5941753912",
     "geom:latitude":13.511018,
     "geom:longitude":-16.05603,
@@ -98,12 +98,13 @@
         "wd:id":"Q1572733",
         "wk:page":"Lower Baddibu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051448,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85266a9d401dac6f1b4b3ea457a4df07",
+    "wof:geomhash":"afa772102ccd67478515b9a165df75bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":890422473,
-    "wof:lastmodified":1582358172,
+    "wof:lastmodified":1695885991,
     "wof:name":"Lower Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/613/890422613.geojson
+++ b/data/890/422/613/890422613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044294,
-    "geom:area_square_m":532429910.887406,
+    "geom:area_square_m":532431624.066968,
     "geom:bbox":"-14.841003,13.430771,-14.449391,13.659279",
     "geom:latitude":13.560395,
     "geom:longitude":-14.61932,
@@ -104,12 +104,13 @@
         "wd:id":"Q728332",
         "wk:page":"Sami District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051455,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0da2b831ed8003526875b194ce808094",
+    "wof:geomhash":"350bbcb0d26dbc66ab52867c507419da",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422613,
-    "wof:lastmodified":1690921839,
+    "wof:lastmodified":1695885991,
     "wof:name":"Sami",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/629/890422629.geojson
+++ b/data/890/422/629/890422629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011342,
-    "geom:area_square_m":136332763.179651,
+    "geom:area_square_m":136332763.391215,
     "geom:bbox":"-15.337634,13.504071,-15.197034,13.637771",
     "geom:latitude":13.571538,
     "geom:longitude":-15.259666,
@@ -104,12 +104,13 @@
         "wd:id":"Q1572232",
         "wk:page":"Niamina West"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051456,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf463051c4d8f9de5edeebef81103ef6",
+    "wof:geomhash":"a0a2c5a0be95c315e47292727f52ab66",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422629,
-    "wof:lastmodified":1690921837,
+    "wof:lastmodified":1695885992,
     "wof:name":"Niamina West",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/631/890422631.geojson
+++ b/data/890/422/631/890422631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029413,
-    "geom:area_square_m":353444270.387803,
+    "geom:area_square_m":353443679.47714,
     "geom:bbox":"-15.199034,13.547693,-14.892234,13.722371",
     "geom:latitude":13.640427,
     "geom:longitude":-15.062894,
@@ -104,12 +104,13 @@
         "wd:id":"Q1626738",
         "wk:page":"Brikama Ba"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051456,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a523ce062eba025ab5e0fc2a79d68309",
+    "wof:geomhash":"be4e382e1d485cbe4410d7e08668dad9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422631,
-    "wof:lastmodified":1690921843,
+    "wof:lastmodified":1695885992,
     "wof:name":"Niamina East",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/649/890422649.geojson
+++ b/data/890/422/649/890422649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023034,
-    "geom:area_square_m":276928192.136768,
+    "geom:area_square_m":276928192.56489,
     "geom:bbox":"-16.307534,13.412671,-16.084634,13.588471",
     "geom:latitude":13.522066,
     "geom:longitude":-16.188126,
@@ -101,12 +101,13 @@
         "wd:id":"Q1572430",
         "wk:page":"Jokadu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051457,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"39fbb2de4341763a4714c361ff2d7f58",
+    "wof:geomhash":"bb96e8fa4e2fcf3bc2534d3a92208e8d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890422649,
-    "wof:lastmodified":1690921840,
+    "wof:lastmodified":1695885992,
     "wof:name":"Jokadu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",

--- a/data/890/422/673/890422673.geojson
+++ b/data/890/422/673/890422673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015045,
-    "geom:area_square_m":180941793.517741,
+    "geom:area_square_m":180941666.119154,
     "geom:bbox":"-15.605123,13.35005,-15.480896,13.514171",
     "geom:latitude":13.433708,
     "geom:longitude":-15.546418,
@@ -107,12 +107,13 @@
         "wd:id":"Q1572209",
         "wk:page":"Jarra West"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051459,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"265658b099e62f2e5d0cc97cc8d9701f",
+    "wof:geomhash":"7b12933479d85c27ff82bf6710e282b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":890422673,
-    "wof:lastmodified":1690921837,
+    "wof:lastmodified":1695885992,
     "wof:name":"Jarra West",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/675/890422675.geojson
+++ b/data/890/422/675/890422675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016044,
-    "geom:area_square_m":192942342.981881,
+    "geom:area_square_m":192942016.12616,
     "geom:bbox":"-15.346991,13.3592,-15.166485,13.556885",
     "geom:latitude":13.453593,
     "geom:longitude":-15.26834,
@@ -104,12 +104,13 @@
         "wd:id":"Q617233",
         "wk:page":"Jarra East"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051459,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"653674cb6b2b955385939e33e70216d9",
+    "wof:geomhash":"71b4f4f350f4c1a1961585fac55c495f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422675,
-    "wof:lastmodified":1690921835,
+    "wof:lastmodified":1695885992,
     "wof:name":"Jarra East",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/679/890422679.geojson
+++ b/data/890/422/679/890422679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01296,
-    "geom:area_square_m":155881618.472085,
+    "geom:area_square_m":155880935.013545,
     "geom:bbox":"-15.481108,13.355788,-15.343628,13.495471",
     "geom:latitude":13.418181,
     "geom:longitude":-15.417774,
@@ -104,12 +104,13 @@
         "wd:id":"Q1572024",
         "wk:page":"Jarra Central"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051459,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0dd8249cbeb5263b1c9e651f7dc1d30",
+    "wof:geomhash":"545a48b44fd68a78764ad32496f75d35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422679,
-    "wof:lastmodified":1690921841,
+    "wof:lastmodified":1695885992,
     "wof:name":"Jarra Central",
     "wof:parent_id":85671521,
     "wof:placetype":"county",

--- a/data/890/422/703/890422703.geojson
+++ b/data/890/422/703/890422703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011602,
-    "geom:area_square_m":139655519.11167,
+    "geom:area_square_m":139654477.838833,
     "geom:bbox":"-16.121887,13.164531,-15.967667,13.297071",
     "geom:latitude":13.225498,
     "geom:longitude":-16.056798,
@@ -104,12 +104,13 @@
         "wd:id":"Q1435754",
         "wk:page":"Foni Kansala"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051460,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"010efd08fdc1ecf00a72618e23f347f0",
+    "wof:geomhash":"615512af1719f569777f2046871ba10f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422703,
-    "wof:lastmodified":1690921839,
+    "wof:lastmodified":1695885992,
     "wof:name":"Foni Kansala",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/705/890422705.geojson
+++ b/data/890/422/705/890422705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008204,
-    "geom:area_square_m":98763533.401844,
+    "geom:area_square_m":98763621.227722,
     "geom:bbox":"-15.89502,13.167101,-15.803606,13.27948",
     "geom:latitude":13.21437,
     "geom:longitude":-15.848889,
@@ -104,12 +104,13 @@
         "wd:id":"Q124275",
         "wk:page":"Foni Jarrol"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051460,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96a1e8a15579e3deb0e542527a92936a",
+    "wof:geomhash":"85abcf6a8bfde5a857bd85d8c908c259",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422705,
-    "wof:lastmodified":1690921838,
+    "wof:lastmodified":1695885992,
     "wof:name":"Foni Jarrol",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/707/890422707.geojson
+++ b/data/890/422/707/890422707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011801,
-    "geom:area_square_m":142066046.097431,
+    "geom:area_square_m":142065084.215943,
     "geom:bbox":"-16.432234,13.165479,-16.274934,13.276971",
     "geom:latitude":13.210472,
     "geom:longitude":-16.357089,
@@ -107,12 +107,13 @@
         "wd:id":"Q1435749",
         "wk:page":"Foni Brefet"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051460,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd770679094d78eb4faa802772f5b6cb",
+    "wof:geomhash":"d659a61dda7432dc53b52df62b6e3b20",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":890422707,
-    "wof:lastmodified":1690921835,
+    "wof:lastmodified":1695885992,
     "wof:name":"Foni Brefet",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/709/890422709.geojson
+++ b/data/890/422/709/890422709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01258,
-    "geom:area_square_m":151436499.696512,
+    "geom:area_square_m":151435648.341516,
     "geom:bbox":"-16.020325,13.16451,-15.888428,13.292471",
     "geom:latitude":13.218498,
     "geom:longitude":-15.954532,
@@ -104,12 +104,13 @@
         "wd:id":"Q1435751",
         "wk:page":"Foni Bondali"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051460,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6f334715757fa85a6b06cf68938ef57",
+    "wof:geomhash":"43e611cf13ab519ae9c0dbc73e4ba729",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890422709,
-    "wof:lastmodified":1690921835,
+    "wof:lastmodified":1695885992,
     "wof:name":"Foni Bondali",
     "wof:parent_id":85671525,
     "wof:placetype":"county",

--- a/data/890/422/845/890422845.geojson
+++ b/data/890/422/845/890422845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010698,
-    "geom:area_square_m":128502225.875471,
+    "geom:area_square_m":128502226.077278,
     "geom:bbox":"-15.212934,13.653471,-14.991434,13.775171",
     "geom:latitude":13.727347,
     "geom:longitude":-15.096319,
@@ -103,12 +103,13 @@
         "wd:id":"Q1572202",
         "wk:page":"Senegambian stone circles"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051468,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b02318c7edde1dd82ac8f1d9cff3325e",
+    "wof:geomhash":"311da02c6fefc71369a9ede9aab2df4f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":890422845,
-    "wof:lastmodified":1690921836,
+    "wof:lastmodified":1695885992,
     "wof:name":"Nianija",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/422/847/890422847.geojson
+++ b/data/890/422/847/890422847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03844,
-    "geom:area_square_m":461833336.18208,
+    "geom:area_square_m":461834837.291539,
     "geom:bbox":"-15.039434,13.5415,-14.725281,13.802899",
     "geom:latitude":13.680995,
     "geom:longitude":-14.879117,
@@ -110,12 +110,13 @@
         "wd:id":"Q1572266",
         "wk:page":"Niani"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051468,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"122de8eb220f52450411222c863c819f",
+    "wof:geomhash":"20c334ac620296105f99b8d79593e21d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":890422847,
-    "wof:lastmodified":1690921840,
+    "wof:lastmodified":1695885992,
     "wof:name":"Niani",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/429/021/890429021.geojson
+++ b/data/890/429/021/890429021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029786,
-    "geom:area_square_m":358243221.109349,
+    "geom:area_square_m":358244519.020636,
     "geom:bbox":"-14.511434,13.323771,-14.237434,13.529505",
     "geom:latitude":13.423048,
     "geom:longitude":-14.373028,
@@ -101,12 +101,13 @@
         "wd:id":"Q1136959",
         "wk:page":"Sandu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051788,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"feba725e2ff08bf8f0c019df65c56058",
+    "wof:geomhash":"946381f35413b8d9d2fced04ed894354",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":890429021,
-    "wof:lastmodified":1690921858,
+    "wof:lastmodified":1695885993,
     "wof:name":"Sandu",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/041/890429041.geojson
+++ b/data/890/429/041/890429041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025447,
-    "geom:area_square_m":306084835.575079,
+    "geom:area_square_m":306085198.522581,
     "geom:bbox":"-14.033534,13.315656,-13.792053,13.510848",
     "geom:latitude":13.402694,
     "geom:longitude":-13.894657,
@@ -104,12 +104,13 @@
         "wd:id":"Q611397",
         "wk:page":"Kantora District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051789,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9aa6b6db076c8871adeb1748d34fac2e",
+    "wof:geomhash":"8eaf6e669827ae1d260f04be454e379e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":890429041,
-    "wof:lastmodified":1690921857,
+    "wof:lastmodified":1695885993,
     "wof:name":"Kantora",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/055/890429055.geojson
+++ b/data/890/429/055/890429055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066736,
-    "geom:area_square_m":802518895.909525,
+    "geom:area_square_m":802518895.909452,
     "geom:bbox":"-15.0618790904,13.324065312,-14.5009336603,13.6128713683",
     "geom:latitude":13.466952,
     "geom:longitude":-14.754784,
@@ -107,12 +107,13 @@
         "wd:id":"Q1473729",
         "wk:page":"Fulladu West"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051790,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a0f15ea72488fc690af361054a4f2279",
+    "wof:geomhash":"485da95c7d45cf144b651aaa893eff44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":890429055,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Fulladu West",
     "wof:parent_id":85671507,
     "wof:placetype":"county",

--- a/data/890/429/057/890429057.geojson
+++ b/data/890/429/057/890429057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06716,
-    "geom:area_square_m":808110676.204434,
+    "geom:area_square_m":808110676.204448,
     "geom:bbox":"-14.5487453402,13.2176272682,-13.9458336603,13.4547713683",
     "geom:latitude":13.319437,
     "geom:longitude":-14.238295,
@@ -110,12 +110,13 @@
         "wd:id":"Q1473721",
         "wk:page":"Fulladu East"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051790,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b349c5c81cb926c7ab6a3e97257dd6c1",
+    "wof:geomhash":"9f987bd6afa7dd282a9dbb99528a09aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":890429057,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885993,
     "wof:name":"Fulladu East",
     "wof:parent_id":85671511,
     "wof:placetype":"county",

--- a/data/890/429/071/890429071.geojson
+++ b/data/890/429/071/890429071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021991,
-    "geom:area_square_m":264390260.592089,
+    "geom:area_square_m":264390260.592096,
     "geom:bbox":"-16.0058336603,13.4417713683,-15.8200336603,13.5928938909",
     "geom:latitude":13.519092,
     "geom:longitude":-15.924566,
@@ -108,12 +108,13 @@
         "wd:id":"Q1053702",
         "wk:page":"Central Baddibu"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GM",
     "wof:created":1469051791,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df2d898b87fb0d74ef7d54894cd71450",
+    "wof:geomhash":"2cdd28e8d996707e5a056ee1a3fca72e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":890429071,
-    "wof:lastmodified":1582358173,
+    "wof:lastmodified":1695885994,
     "wof:name":"Central Baddibu",
     "wof:parent_id":85671529,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.